### PR TITLE
Update template.tex

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -63,6 +63,13 @@
 \end{frame}
 }
 
+%%%	------------------------
+%%%	prevents error compilation error due to a recent change in LaTeX
+\makeatletter
+\let\@@magyar@captionfix\relax
+\makeatother
+%%%	------------------------
+
 \begin{document}
 
 


### PR DESCRIPTION
+ Current version does not compile due to a change in LaTeX's kernel, see https://tex.stackexchange.com/questions/426088/texlive-pretest-2018-beamer-and-subfig-collide